### PR TITLE
Add CHANGELOG for v0.2.0. Closes #4

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,4 +2,4 @@
 
 _What's new?_
 
-- Added support for setting [connection configuration](https://github.com/turbot/steampipe-plugin-zendesk/blob/main/docs/index.md#connection-configuration) arguments for the plugin.
+- Added support for [connection configuration](https://github.com/turbot/steampipe-plugin-zendesk/blob/main/docs/index.md#connection-configuration). You may specify zendesk `subdomain`, `email` and `token` for each connection in a configuration file. You can have multiple zendesk connections, each configured for a different zendesk account.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,5 @@
+## v0.2.0 [2021-02-18]
+
+_What's new?_
+
+- Added support for setting [connection configuration](https://github.com/turbot/steampipe-plugin-zendesk/blob/main/docs/index.md#connection-configuration) arguments for the plugin.

--- a/README.md
+++ b/README.md
@@ -7,10 +7,6 @@
   <a aria-label="Steampipe logo" href="https://steampipe.io">
     <img src="https://steampipe.io/images/steampipe_logo_wordmark_padding.svg" height="28">
   </a>
-  <a aria-label="Plugin version" href="https://hub.steampipe.io/plugins/turbot/zendesk">
-    <img alt="" src="https://img.shields.io/static/v1?label=turbot/zendesk&message=v0.1.0&style=for-the-badge&labelColor=777777&color=F3F1F0">
-  </a>
-  &nbsp;
   <a aria-label="License" href="LICENSE">
     <img alt="" src="https://img.shields.io/static/v1?label=license&message=MPL-2.0&style=for-the-badge&labelColor=777777&color=F3F1F0">
   </a>

--- a/go.mod
+++ b/go.mod
@@ -4,5 +4,5 @@ go 1.15
 
 require (
 	github.com/nukosuke/go-zendesk v0.9.0
-	github.com/turbot/steampipe-plugin-sdk v0.2.0-rc.1
+	github.com/turbot/steampipe-plugin-sdk v0.2.0
 )

--- a/go.sum
+++ b/go.sum
@@ -122,8 +122,8 @@ github.com/tkrajina/go-reflector v0.5.4 h1:dS9aJEa/eYNQU/fwsb5CSiATOxcNyA/gG/A7a
 github.com/tkrajina/go-reflector v0.5.4/go.mod h1:9PyLgEOzc78ey/JmQQHbW8cQJ1oucLlNQsg8yFvkVk8=
 github.com/turbot/go-kit v0.1.1 h1:JkLUyVp8m8jEj45C52dzh7Tj9jpxHP90y9+m8cpW1mo=
 github.com/turbot/go-kit v0.1.1/go.mod h1:hO/mY90fJXLWAJnAoDkYMvi3LVZ/r+z1tiz3E1uPSNA=
-github.com/turbot/steampipe-plugin-sdk v0.2.0-rc.1 h1:6LbX0zl1d4VU+p/a6C/rr7e2f1do/D6FIJGJ7oKGLEo=
-github.com/turbot/steampipe-plugin-sdk v0.2.0-rc.1/go.mod h1:3R868UGCRVR5ptSpYY+zGetiq2ZqjVDP8wlrapVh6rc=
+github.com/turbot/steampipe-plugin-sdk v0.2.0 h1:TRRunONpZS3erUOPjkl0LzAUBkBwp+Z6VkwixZoWe0M=
+github.com/turbot/steampipe-plugin-sdk v0.2.0/go.mod h1:3R868UGCRVR5ptSpYY+zGetiq2ZqjVDP8wlrapVh6rc=
 github.com/vmihailenco/msgpack v3.3.3+incompatible/go.mod h1:fy3FlTQTDXWkZ7Bh6AcGMlsjHatGryHQYUTf1ShIgkk=
 github.com/vmihailenco/msgpack/v4 v4.3.12/go.mod h1:gborTTJjAo/GWTqqRjrLCn9pgNN+NXzzngzBKDPIqw4=
 github.com/vmihailenco/tagparser v0.1.1/go.mod h1:OeAg3pn3UbLjkWt+rN9oFYB6u/cQgqMEUPoW2WPyhdI=

--- a/zendesk/utils.go
+++ b/zendesk/utils.go
@@ -34,15 +34,15 @@ func connect(ctx context.Context, d *plugin.QueryData) (*zendesk.Client, error) 
 	}
 
 	if subdomain == "" {
-		return nil, errors.New("'subdomain' must be set in the connection configuration")
+		return nil, errors.New("'subdomain' must be set in the connection configuration. Edit your connection configuration file and then restart Steampipe")
 	}
 
 	if user == "" {
-		return nil, errors.New("'email' must be set in the connection configuration")
+		return nil, errors.New("'email' must be set in the connection configuration. Edit your connection configuration file and then restart Steampipe")
 	}
 
 	if token == "" {
-		return nil, errors.New("'token' must be set in the connection configuration")
+		return nil, errors.New("'token' must be set in the connection configuration. Edit your connection configuration file and then restart Steampipe")
 	}
 
 	// example.zendesk.com


### PR DESCRIPTION
## v0.2.0 [2021-02-18]

_What's new?_

- Added support for [connection configuration](https://github.com/turbot/steampipe-plugin-zendesk/blob/main/docs/index.md#connection-configuration). You may specify zendesk `subdomain`, `email` and `token` for each connection in a configuration file. You can have multiple zendesk connections, each configured for a different zendesk account.