### PR TITLE
Change column type of `external_id` in `zendesk_ticket` table to text

### DIFF
--- a/zendesk/table_zendesk_ticket.go
+++ b/zendesk/table_zendesk_ticket.go
@@ -32,7 +32,7 @@ func tableZendeskTicket() *plugin.Table {
 			{Name: "description", Type: proto.ColumnType_STRING, Description: "Read-only first comment on the ticket. When creating a ticket, use comment to set the description."},
 			{Name: "due_at", Type: proto.ColumnType_TIMESTAMP, Description: "If this is a ticket of type \"task\" it has a due date. Due date format uses ISO 8601 format."},
 			{Name: "email_cc_ids", Type: proto.ColumnType_JSON, Description: "The ids of agents or end users currently CC'ed on the ticket."},
-			{Name: "external_id", Type: proto.ColumnType_INT, Description: "An id you can use to link Zendesk Support tickets to local records"},
+			{Name: "external_id", Type: proto.ColumnType_STRING, Description: "An id you can use to link Zendesk Support tickets to local records"},
 			{Name: "follower_ids", Type: proto.ColumnType_JSON, Description: "The ids of agents currently following the ticket."},
 			{Name: "followup_ids", Type: proto.ColumnType_JSON, Description: "The ids of the followups created from this ticket. Ids are only visible once the ticket is closed"},
 			{Name: "forum_topic_id", Type: proto.ColumnType_INT, Description: "The topic in the Zendesk Web portal this ticket originated from, if any. The Web portal is deprecated"},


### PR DESCRIPTION
The "external_id" reponse from Zendesk API may be a string, for example if an extnernal ID is a side conversation in to slack, causing a failure:

```
steampipe=> select created_at, description, id, status, subject from zendesk_ticket where organization_id ='361091712552' ; ERROR:  rpc error: code = Unknown desc = interfaceToColumnValue failed for column 'external_id': strconv.ParseInt: parsing "zen:side_conversation:7f21fa9b-ae2f-11ed-b2ad-ec87d0fe7ae2:ticket:1234": invalid syntax
```


Changing this column type to text resolves this error

